### PR TITLE
Reset checkbox value when it is unchecked

### DIFF
--- a/form.go
+++ b/form.go
@@ -537,6 +537,17 @@ func (form *Form) BindFromPost(req *http.Request) {
 		field.SetValue(value[0])
 	}
 
+	// handle situation when checkboxes has default value set to checked/true and the value is not reset because
+	// unchecked checkbox is not in the request
+	for _, field := range form.GetElements() {
+		if field.GetType() == ElementTypeCheckbox {
+			if _, ok := req.PostForm[field.GetName()]; !ok {
+				// "false" can be parsed and assigned to bool in f.MapTo() later
+				field.SetValue("false")
+			}
+		}
+	}
+
 	if req.Header.Get("Content-Type") != "" {
 		if strings.Fields(req.Header.Get("Content-Type"))[0] == "multipart/form-data;" {
 			req.ParseMultipartForm(0)


### PR DESCRIPTION
This PR fixes situation when form is initialised with some default values and leave these default values for checkboxes that were unchecked by the user - unchecked checkboxes are not present in the request.

e.g.

```go
type ProfileModel struct {
	IsVerified bool
	IsBlocked  bool
}

...
isVerified := goform.NewCheckboxElement("is_verified", "Verified", []*goform.Attribute{}, []goform.ValidatorInterface{}, []goform.FilterInterface{})
isBlocked := goform.NewCheckboxElement("is_blocked", "Blocked", []*goform.Attribute{}, []goform.ValidatorInterface{}, []goform.FilterInterface{})
submit := goform.NewSubmitElement("save", "Save", []*goform.Attribute{})

isVerified.SetValue(strconv.FormatBool(profile.IsVerified))
isBlocked.SetValue(strconv.FormatBool(profile.IsBlocked))

profileForm := goform.NewGoForm()
profileForm.Add(isVerified)
profileForm.Add(isBlocked)
profileForm.Add(submit)

if r.Method == http.MethodPost {
    r.ParseForm()
    profileForm.BindFromRequest(r)

    profileModel := new(ProfileModel)
    profileForm.MapTo(profileModel)
    ...
}
...
```

When profile is blocked (`is_blocked` checked) and then user unchecks `is_blocked` it and submits the form model keeps `true` value because `is_blocked` is not in the request.