### PR TITLE
Use Bootstrap4Textual as default theme

### DIFF
--- a/form.go
+++ b/form.go
@@ -53,7 +53,7 @@ type Form struct {
 
 func NewGoForm() *Form {
 	return &Form{
-		theme: ThemeBootstrap4alpha6Textual,
+		theme: ThemeBootstrap4Textual,
 	}
 }
 


### PR DESCRIPTION
Bootstrap4 released long time ago and with `ThemeBootstrap4alpha6Textual` set as default theme some elements looks "broken" (e.g. checkboxes) unless non-alpha theme is set explicitly.